### PR TITLE
Increase Nginx proxy timeout to 10 minutes to process bigger / cruft stories

### DIFF
--- a/nginx.conf.d/increase-timeout.conf
+++ b/nginx.conf.d/increase-timeout.conf
@@ -1,0 +1,9 @@
+# Small amount of stories processed through the labeller are large quasi-binary
+# cruft which make the proxy Nginx run out of the default 60 s timeout.
+# The cruft stories are hard to detect on the client side, so we just wait it
+# out on the proxy until the underlying labeler comes up with something to
+# return.
+proxy_connect_timeout 600s;
+proxy_send_timeout 600s;
+proxy_read_timeout 600s;
+send_timeout 600s;


### PR DESCRIPTION
Probably fixes https://github.com/berkmancenter/mediacloud-systems/issues/49.

Not tested, but [looks about right](https://github.com/dokku/dokku/blob/master/docs/configuration/nginx.md#customizing-via-configuration-files-included-by-the-default-templates).