### PR TITLE
Disable mmap()'ping word2vec model (for now)

### DIFF
--- a/labeller/models.py
+++ b/labeller/models.py
@@ -44,7 +44,7 @@ def _vectors_file_exists():
 def _load_vectors_file():
     global word2vecmodel
     logger.info("Loading pre-trained word2vec model...")
-    word2vecmodel = gensim.models.KeyedVectors.load(_path_to_vectors_file(), mmap='r')
+    word2vecmodel = gensim.models.KeyedVectors.load(_path_to_vectors_file())
     logger.info("Loaded pre-trained word2vec model.")
 
 


### PR DESCRIPTION
Doesn't appear to work correctly when loaded in a Docker container: if multiple instances of an image get started (e.g. as a swarm service), neither containers seem to be able to load the word2vec model.

There are other ways to get around this, but for now it's not critical - we can just load the 4 GB module for each worker independently.

Ping @rahulbot.
